### PR TITLE
Update examples to use QUnit.pushResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ For example:
 ```javascript
 // tests/assertions/contains.js
 export default function(context, element, text, message) {
-  var matches = context.$(element).text().match(new RegExp(text));
   message = message || `${element} should contain "${text}"`;
+  let actual = context.$(element).text();
+  let expected = text;
+  let result = !!actual.match(new RegExp(expected));
 
-  this.push(!!matches, matches, text, message);
+  this.pushResult({ result, actual, expected, message });
 }
 
 // tests/acceptance/foo-test.js

--- a/blueprints/assertion/files/tests/assertions/__name__.js
+++ b/blueprints/assertion/files/tests/assertions/__name__.js
@@ -1,4 +1,4 @@
 export default function <%= camelName %>(/* context, arg1, arg2 */) {
-  // use this.push to add the assertion.
-  // see: https://api.qunitjs.com/push/ for more information
+  // use this.pushResult to add the assertion.
+  // see: https://api.qunitjs.com/pushResult/ for more information
 }

--- a/tests/assertions/double-trouble.js
+++ b/tests/assertions/double-trouble.js
@@ -1,4 +1,4 @@
 export default function doubleTrouble() {
-  this.push(true);
-  this.push(true);
+  this.pushResult({ result: true });
+  this.pushResult({ result: true });
 }


### PR DESCRIPTION
## Changes proposed in this pull request
* Update references to `QUnit.push` to use `QUnit.pushResult` since `QUnit.push` has been deprecated.