### PR TITLE
Fix cleanup

### DIFF
--- a/test-support/assertions.js
+++ b/test-support/assertions.js
@@ -48,8 +48,8 @@ function assertionInjector(context) {
 function assertionCleanup() {
   let _assertions = assertions();
 
-  Object.keys(_assertions).forEach(function() {
-    delete window.QUnit.assert[assertions];
+  Object.keys(_assertions).forEach(function(assertion) {
+    delete window.QUnit.assert[assertion];
   });
 }
 


### PR DESCRIPTION
The cleanup function now removes the custom assertions. This fixes a bug where Ember tests that injected custom assertions were leaking memory.
